### PR TITLE
Fix README.md formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ can be found in the HedyNet/HedyNet/wsgi.py file.
 
 Best practices involve using virtualenv.  Then, one can:
 
- pip install -r requirements/local.txt
+    pip install -r requirements/local.txt
 
 To install the necessary Python dependencies.  The virtualenv environment
 will also need those environment variables to be set in this environment file:
 
- bin/postactivate
+    bin/postactivate
 
 Additionally, in order to compile the SCSS into CSS, Ruby is required with the
 following gems installed:
 
-  gem install zurb-foundation
-  gem install compass
+    gem install zurb-foundation
+    gem install compass
 
 If you are using apache, there is an example config in HedyNet/apache.
 
@@ -35,14 +35,14 @@ Do these commands from the base HedyNet directory.
 
 First, one can use Django's collectstatic:
 
-  ./manage.py collectstatic
+    ./manage.py collectstatic
 
 Then in the HedyNet directory, one can use:
 
-  compass compile
+    compass compile
 
 To do a single compile, or:
 
-  compass watch
+    compass watch
 
 To continually watch the SCSS files for changes and recompile.


### PR DESCRIPTION
The instructions formatting requires four spaces.